### PR TITLE
Release CI: Fix typo (maybe)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
           echo ":github: Bearer ${{ secrets.GITHUB_TOKEN }}" >> ~/.gem/credentials
           chmod 0600 ~/.gem/credentials
       - name: Publish gem to GitHub packages
-        run: gem push --key github --host https://rubygems.pkg.github.com/openvoxproject *.gem
+        run: gem push --key github --host https://rubygems.pkg.github.com/OpenVoxProject *.gem
       - name: Create Release Page
         shell: bash
         env:


### PR DESCRIPTION
The last release failed with:

```
Run gem push --key github --host https://rubygems.pkg.github.com/openvoxproject *.gem
  gem push --key github --host https://rubygems.pkg.github.com/openvoxproject *.gem
  shell: /usr/bin/bash -e {0}
  env:
    RUBYGEMS_API_KEY: ***
    BUNDLE_GEM__PUSH_KEY: ***
    GEM_HOST_API_KEY: ***

Pushing gem to https://rubygems.pkg.github.com/openvoxproject...
Your request could not be authenticated by the GitHub Packages service. Please ensure your access token is valid and has the appropriate scopes configured.
Error: Process completed with exit code 1.
```

And I guess that's because it's case sensitive, maybe?