### PR TITLE
CI: Test jruby-9.4.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,6 +46,10 @@ jobs:
           - {os: ubuntu-24.04, ruby: '3.3'} # openssl 3
           - {os: ubuntu-24.04, ruby: '3.4'} # openssl 3
           - {os: ubuntu-22.04, ruby: 'jruby-9.4.3'} # what Perforce used in their CI
+          - {os: ubuntu-22.04, ruby: 'jruby-9.4.4'}
+          - {os: ubuntu-22.04, ruby: 'jruby-9.4.5'}
+          - {os: ubuntu-22.04, ruby: 'jruby-9.4.6'}
+          - {os: ubuntu-22.04, ruby: 'jruby-9.4.7'}
           - {os: ubuntu-22.04, ruby: 'jruby-9.4.8' } # what Openvox packages
           - {os: ubuntu-22.04, ruby: 'jruby-9.4.13' } # latest
           - {os: windows-2025, ruby: '3.1'}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
           - {os: ubuntu-24.04, ruby: '3.2'} # openssl 3
           - {os: ubuntu-24.04, ruby: '3.3'} # openssl 3
           - {os: ubuntu-24.04, ruby: '3.4'} # openssl 3
-          - {os: ubuntu-24.04, ruby: 'jruby-9.4'}
+          - {os: ubuntu-22.04, ruby: 'jruby-9.4.3'}
           - {os: windows-2025, ruby: '3.1'}
           - {os: windows-2025, ruby: '3.2'} # openssl 3
           - {os: windows-2025, ruby: '3.3'} # openssl 3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,9 @@ jobs:
           - {os: ubuntu-24.04, ruby: '3.2'} # openssl 3
           - {os: ubuntu-24.04, ruby: '3.3'} # openssl 3
           - {os: ubuntu-24.04, ruby: '3.4'} # openssl 3
-          - {os: ubuntu-22.04, ruby: 'jruby-9.4.3'}
+          - {os: ubuntu-22.04, ruby: 'jruby-9.4.3'} # what Perforce used in their CI
+          - {os: ubuntu-22.04, ruby: 'jruby-9.4.8' } # what Openvox packages
+          - {os: ubuntu-22.04, ruby: 'jruby-9.4.13' } # latest
           - {os: windows-2025, ruby: '3.1'}
           - {os: windows-2025, ruby: '3.2'} # openssl 3
           - {os: windows-2025, ruby: '3.3'} # openssl 3


### PR DESCRIPTION
We have some weird JRuby issues on main. Previously we pinned to JRuby-9.4 on Ubuntu-24.04. That currently gives us https://github.com/ruby/ruby-builder/releases/download/toolcache/jruby-9.4.13.0-ubuntu-24.04.tar.gz

The old Perforce CI was pinned to jruby-9.4.3.0 on Ubuntu 22.04, lets try that.