### PR TITLE
Remove facter from install.rb

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -38,8 +38,6 @@ require 'ostruct'
 
 IS_WINDOWS = RUBY_PLATFORM.match?(/(mswin|mingw)/)
 
-PREREQS = %w{openssl cgi}
-
 InstallOptions = OpenStruct.new
 
 def glob(list)
@@ -98,24 +96,11 @@ def do_locales(locale, strip = 'locales/')
   end
 end
 
-# Verify that all of the prereqs are installed
-def check_prereqs
-  PREREQS.each { |pre|
-    begin
-      require pre
-    rescue LoadError
-      puts "Could not load #{pre}; cannot install"
-      exit(-1)
-    end
-  }
-end
-
 ##
 # Prepare the file installation.
 #
 def prepare_installation
   InstallOptions.configs = true
-  InstallOptions.check_prereqs = true
   InstallOptions.batch_files = true
 
   ARGV.options do |opts|
@@ -159,9 +144,6 @@ def prepare_installation
     end
     opts.on('--mandir[=OPTIONAL]', 'Installation directory for man pages', 'overrides RbConfig::CONFIG["mandir"]') do |mandir|
       InstallOptions.mandir = mandir
-    end
-    opts.on('--[no-]check-prereqs', 'Prevents validation of prerequisite libraries', 'Default on') do |prereq|
-      InstallOptions.check_prereqs = prereq
     end
     opts.on('--no-batch-files', 'Prevents installation of batch files for windows', 'Default off') do |batch_files|
       InstallOptions.batch_files = false

--- a/install.rb
+++ b/install.rb
@@ -85,9 +85,7 @@ def do_man(man, strip = 'man/')
     # Solaris does not support gzipped man pages. When called with
     # --no-check-prereqs/without facter the default gzip behavior still applies
     unless $osname == "Solaris"
-      gzip = %x{which gzip}
-      gzip.chomp!
-      %x{#{gzip} --force --no-name #{omf}}
+      %x{gzip --force --no-name #{omf}}
     end
   end
 end

--- a/install.rb
+++ b/install.rb
@@ -82,11 +82,7 @@ def do_man(man, strip = 'man/')
     FileUtils.makedirs(om, mode: 0755, verbose: true)
     FileUtils.chmod(0755, om)
     FileUtils.install(mf, omf, mode: 0644, preserve: true, verbose: true)
-    # Solaris does not support gzipped man pages. When called with
-    # --no-check-prereqs/without facter the default gzip behavior still applies
-    unless $osname == "Solaris"
-      %x{gzip --force --no-name #{omf}}
-    end
+    %x{gzip --force --no-name #{omf}}
   end
 end
 


### PR DESCRIPTION
This drops the use of Facter in `install.rb`. It drops Solaris support and then rewrites the Windows detect to use `RUBY_PLATFORM` instead. It then also drops the prereq checking since that doesn't really serve a purpose anymore.