### PR TITLE
Allow latest fast_gettext

### DIFF
--- a/openvox.gemspec
+++ b/openvox.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('benchmark', '>= 0.3', '< 0.5')
   spec.add_runtime_dependency('concurrent-ruby', '~> 1.0')
   spec.add_runtime_dependency('deep_merge', '~> 1.0')
-  spec.add_runtime_dependency('fast_gettext', '>= 2.1', '< 4')
+  spec.add_runtime_dependency('fast_gettext', '>= 2.1', '< 5')
   spec.add_runtime_dependency('getoptlong', '~> 0.2.0')
   spec.add_runtime_dependency('locale', '~> 2.1')
   spec.add_runtime_dependency('multi_json', '~> 1.13')


### PR DESCRIPTION
This is not enougth to update fast_gettext when using bundler because we
depend on gettext-setup which in turn depends on fast_gettext ~> 2.1.
But in the context of non-AIO install like we have on FreeBSD it allows
us to get rid of local patches.
