### PR TITLE
Respect systemd's RUNTIME_DIRECTORY environment variable

### DIFF
--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -81,7 +81,7 @@ module Puppet
       end
 
       def run_dir
-        which_dir("/var/run/puppetlabs", "~/.puppetlabs/var/run")
+        ENV.fetch('RUNTIME_DIRECTORY') { which_dir("/var/run/puppetlabs", "~/.puppetlabs/var/run") }
       end
 
       def log_dir


### PR DESCRIPTION
Systemd will export the environment variable RUNTIME_DIRECTORY when running a deamon. This avoids the need for shipping a tmpfiles.d entry to create the run directory.

Link: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=

This relates to https://github.com/OpenVoxProject/planning/issues/69. I don't quite know this will interact because I don't know if this method will also be read by the clojure code.