### PR TITLE
Ensure confdir exists

### DIFF
--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -171,6 +171,7 @@ Puppet::Face.define(:config, '0.0.1') do
       end
 
       path = Puppet::FileSystem.pathname(Puppet.settings.which_configuration_file)
+      Puppet::FileSystem.dir_mkpath(path)
       Puppet::FileSystem.touch(path)
       Puppet::FileSystem.open(path, nil, 'r+:UTF-8') do |file|
         Puppet::Settings::IniFile.update(file) do |config|

--- a/spec/unit/face/config_spec.rb
+++ b/spec/unit/face/config_spec.rb
@@ -131,6 +131,7 @@ trace = true
     before(:each) do
       Puppet[:config] = config_file
       allow(Puppet::FileSystem).to receive(:pathname).with(path.to_s).and_return(path)
+      allow(Puppet::FileSystem).to receive(:dir_mkpath)
       allow(Puppet::FileSystem).to receive(:touch)
     end
 


### PR DESCRIPTION
Prior to this, if OpenVox was installed via gem and the first command you run is setting configuration then it fails because `confdir` doesn't exist yet. This corrects that.

It doesn't bother setting permissions because future runs will correct the permissions.