### PR TITLE
treat windows service accounts as case insensitive

### DIFF
--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -127,7 +127,7 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
     @normalized_logon_account ||= normalize_logonaccount
     @resource[:logonaccount] = @normalized_logon_account
 
-    insync = @resource[:logonaccount] == current
+    insync = @resource[:logonaccount].casecmp?(current)
     self.logonpassword = @resource[:logonpassword] if insync
     insync
   end


### PR DESCRIPTION
Windows service accounts are *case preserving* but not *case sensitive*.

Before this change, Windows service logon account names were compared directly as case sensitive. When there was a case mismatch, it was treated as a change to the account and the service was restarted. This now normalizes case before comparing, reducing spurious restarts.