### PR TITLE
CI: Downgrade Windows 2025->2022

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,10 +46,10 @@ jobs:
           - {os: ubuntu-24.04, ruby: '3.3'} # openssl 3
           - {os: ubuntu-24.04, ruby: '3.4'} # openssl 3
           - {os: ubuntu-24.04, ruby: 'jruby-9.4'}
-          - {os: windows-2025, ruby: '3.1'}
-          - {os: windows-2025, ruby: '3.2'} # openssl 3
-          - {os: windows-2025, ruby: '3.3'} # openssl 3
-          - {os: windows-2025, ruby: '3.4'} # openssl 3
+          - {os: windows-2022, ruby: '3.1'}
+          - {os: windows-2022, ruby: '3.2'} # openssl 3
+          - {os: windows-2022, ruby: '3.3'} # openssl 3
+          - {os: windows-2022, ruby: '3.4'} # openssl 3
 
     runs-on: ${{ matrix.cfg.os }}
     steps:


### PR DESCRIPTION
Windows 2025 after ~ July introduced CI errors:

```
Failures:

  1) directory environments with a single directory environmentpath given an 8.3 style path on Windows, will config print an expanded path
     Failure/Error: expect(Puppet[:environmentpath]).to match(/~/)
       expected "D:/a/_temp/rspecrun20250824-4932-upmga8/envpath20250824-4932-uz5uk2" to match /~/
       Diff:
       @@ -1 +1 @@
       -/~/
       +"D:/a/_temp/rspecrun20250824-4932-upmga8/envpath20250824-4932-uz5uk2"
     # ./spec/integration/directory_environments_spec.rb:39:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:180:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # util/rspec_runner:47:in `run'
     # util/rspec_runner:61:in `<main>'
  2) Puppet::Node::Environment should expand 8.3 paths on Windows when creating an environment
     Failure/Error: expect(parent_modules_dir).to match(/~/)
       expected "D:/a/_temp/rspecrun20250824-4932-upmga8/env_modules20250824-4932-djk7c8/testmoduledir" to match /~/
       Diff:
       @@ -1 +1 @@
       -/~/
       +"D:/a/_temp/rspecrun20250824-4932-upmga8/env_modules20250824-4932-djk7c8/testmoduledir"
     # ./spec/integration/node/environment_spec.rb:47:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:180:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # util/rspec_runner:47:in `run'
     # util/rspec_runner:61:in `<main>'
Finished in 1 minute 32.25 seconds (files took 6.01 seconds to load)

  1) Puppet::Util::Autoload when loading all files autoloads from a directory whose ancestor is Windows 8.3
     Failure/Error: expect(Kernel).to receive(:load).with(path83, any_args)
       (Kernel).load("D:/a/_temp/rspecrun20250824-7504-59wez2/longpa~1/short/tmp/file.rb", *(any args))
           expected: 1 time with arguments: ("D:/a/_temp/rspecrun20250824-7504-59wez2/longpa~1/short/tmp/file.rb", *(any args))
           received: 0 times
     # ./spec/unit/util/autoload_spec.rb:218:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:180:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # util/rspec_runner:47:in `run'
     # util/rspec_runner:61:in `<main>'
Finished in 1 minute 22.68 seconds (files took 4.8 seconds to load)

  1) Puppet::FileSystem symlink expand_path on Windows should expand a shortened path completely, unlike Ruby File.expand_path
     Failure/Error: expect(short_path).to match(/~.*~/)
       expected "D:/a/_temp/rspecrun20250824-5588-z63xzn/super-long-thing-that-Windows-shortens20250824-5588-35x7ca" to match /~.*~/
       Diff:
       @@ -1 +1 @@
       -/~.*~/
       +"D:/a/_temp/rspecrun20250824-5588-z63xzn/super-long-thing-that-Windows-shortens20250824-5588-35x7ca"
     # ./spec/unit/file_system_spec.rb:918:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:180:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # util/rspec_runner:47:in `run'
     # util/rspec_runner:61:in `<main>'
Finished in 1 minute 8.38 seconds (files took 4.15 seconds to load)

Finished in 21 minutes 17 seconds
25158 examples, 4 failures, 70 pending

Failed examples:
rspec ./spec/integration/directory_environments_spec.rb:31 # directory environments with a single directory environmentpath given an 8.3 style path on Windows, will config print an expanded path
rspec ./spec/integration/node/environment_spec.rb:39 # Puppet::Node::Environment should expand 8.3 paths on Windows when creating an environment
rspec ./spec/unit/util/autoload_spec.rb:205 # Puppet::Util::Autoload when loading all files autoloads from a directory whose ancestor is Windows 8.3
rspec ./spec/unit/file_system_spec.rb:910 # Puppet::FileSystem symlink expand_path on Windows should expand a shortened path completely, unlike Ruby File.expand_path
```