### PR TITLE
Reapply "Mark some failing 8.3 Windows tests as pending"

### DIFF
--- a/spec/integration/directory_environments_spec.rb
+++ b/spec/integration/directory_environments_spec.rb
@@ -30,6 +30,7 @@ describe "directory environments" do
 
     it 'given an 8.3 style path on Windows, will config print an expanded path',
       :if => Puppet::Util::Platform.windows? do
+      pending("GH runners seem to have disabled 8.3 support")
 
       # ensure an 8.3 style path is set for environmentpath
       shortened = Puppet::Util::Windows::File.get_short_pathname(Puppet[:environmentpath])

--- a/spec/integration/node/environment_spec.rb
+++ b/spec/integration/node/environment_spec.rb
@@ -38,6 +38,7 @@ describe Puppet::Node::Environment do
 
   it "should expand 8.3 paths on Windows when creating an environment",
     :if => Puppet::Util::Platform.windows? do
+    pending("GH runners seem to have disabled 8.3 support")
 
     # asking for short names only works on paths that exist
     base = Puppet::Util::Windows::File.get_short_pathname(tmpdir("env_modules"))

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -908,6 +908,8 @@ describe "Puppet::FileSystem" do
         end
 
         it 'should expand a shortened path completely, unlike Ruby File.expand_path' do
+          pending("GH runners seem to have disabled 8.3 support")
+
           tmp_long_dir = tmpdir('super-long-thing-that-Windows-shortens')
           short_path = Puppet::Util::Windows::File.get_short_pathname(tmp_long_dir)
 

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -203,6 +203,8 @@ describe Puppet::Util::Autoload do
     end
 
     it "autoloads from a directory whose ancestor is Windows 8.3", if: Puppet::Util::Platform.windows? do
+      pending("GH runners seem to have disabled 8.3 support")
+
       # File.expand_path will expand ~ in the last directory component only(!)
       # so create an ancestor directory with a long path
       dir = File.join(tmpdir('longpath'), 'short')


### PR DESCRIPTION
This reverts commit f614c46ca7889fa3038d60f4740f2ce0ae980524.

soooooooooo
Initially, tests for windows in the 8.3 format
(https://en.wikipedia.org/wiki/Tilde#Microsoft_filenames) were marked as pending. See also https://github.com/puppetlabs/puppet/issues/9371. They started to pass, probably by accident, in July: https://github.com/OpenVoxProject/openvox/pull/159

I think GitHub enabled 8.3 compatibility by accident in one runner release and fixed it aftwards. That was on the 2025 runners. Previously Perforce used the 2019/2022 runners, and 2022 was windows-latest at that time. Maybe github disabled the 8.3 support in 2025, to stay compatible with windows 2022. After this change, the switched windows-latest from 2022 to 2025.