### PR TITLE
`yum` package provider: add `assumeyes` to `yum check-update`

### DIFF
--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -111,7 +111,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   # @return [Hash<String, Array<Hash<String, String>>>] All packages that were
   #   found with a list of found versions for each package.
   def self.check_updates(disablerepo, enablerepo, disableexcludes)
-    args = [command(:cmd), 'check-update']
+    args = [command(:cmd), '-y', 'check-update']
     args.concat(disablerepo.map { |repo| ["--disablerepo=#{repo}"] }.flatten)
     args.concat(enablerepo.map { |repo| ["--enablerepo=#{repo}"] }.flatten)
     args.concat(disableexcludes.map { |repo| ["--disableexcludes=#{repo}"] }.flatten)

--- a/spec/shared_examples/rhel_package_provider.rb
+++ b/spec/shared_examples/rhel_package_provider.rb
@@ -327,7 +327,7 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
     describe "executing #{provider_name} check-update" do
       it "passes repos to enable to '#{provider_name} check-update'" do
         expect(Puppet::Util::Execution).to receive(:execute).with(
-          %W[/usr/bin/#{provider_name} check-update --enablerepo=updates --enablerepo=centosplus],
+          %W[/usr/bin/#{provider_name} -y check-update --enablerepo=updates --enablerepo=centosplus],
           any_args
         ).and_return(double(:exitstatus => 0))
         described_class.check_updates([], %W[updates centosplus], [])
@@ -335,7 +335,7 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
 
       it "passes repos to disable to '#{provider_name} check-update'" do
         expect(Puppet::Util::Execution).to receive(:execute).with(
-          %W[/usr/bin/#{provider_name} check-update --disablerepo=updates --disablerepo=centosplus],
+          %W[/usr/bin/#{provider_name} -y check-update --disablerepo=updates --disablerepo=centosplus],
           any_args
         ).and_return(double(:exitstatus => 0))
         described_class.check_updates(%W[updates centosplus], [], [])
@@ -343,7 +343,7 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
 
       it "passes a combination of repos to enable and disable to '#{provider_name} check-update'" do
         expect(Puppet::Util::Execution).to receive(:execute).with(
-          %W[/usr/bin/#{provider_name} check-update --disablerepo=updates --disablerepo=centosplus --enablerepo=os --enablerepo=contrib ],
+          %W[/usr/bin/#{provider_name} -y check-update --disablerepo=updates --disablerepo=centosplus --enablerepo=os --enablerepo=contrib ],
           any_args
         ).and_return(double(:exitstatus => 0))
         described_class.check_updates(%W[updates centosplus], %W[os contrib], [])
@@ -351,7 +351,7 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
 
       it "passes disableexcludes to '#{provider_name} check-update'" do
         expect(Puppet::Util::Execution).to receive(:execute).with(
-          %W[/usr/bin/#{provider_name} check-update --disableexcludes=main --disableexcludes=centosplus],
+          %W[/usr/bin/#{provider_name} -y check-update --disableexcludes=main --disableexcludes=centosplus],
           any_args
         ).and_return(double(:exitstatus => 0))
         described_class.check_updates([], [], %W[main centosplus])
@@ -359,7 +359,7 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
 
       it "passes all options to '#{provider_name} check-update'" do
         expect(Puppet::Util::Execution).to receive(:execute).with(
-          %W[/usr/bin/#{provider_name} check-update --disablerepo=a --disablerepo=b --enablerepo=c --enablerepo=d --disableexcludes=e --disableexcludes=f],
+          %W[/usr/bin/#{provider_name} -y check-update --disablerepo=a --disablerepo=b --enablerepo=c --enablerepo=d --disableexcludes=e --disableexcludes=f],
           any_args
         ).and_return(double(:exitstatus => 0))
         described_class.check_updates(%W[a b], %W[c d], %W[e f])


### PR DESCRIPTION
This solves the observed issue (on at least RHEL8)  if repo_gpgcheck=1 AND baseurl is changed (by a yumrepo resources for example) AND no other puppet package with dnf -y (assumeyes) has been run then dnf asks to re-import already imported keys (the key needs to be imported into dnf's databases, which is separate from rpm database and it is a new database per baseurl https://bugzilla.redhat.com/show_bug.cgi?id=1768206). If puppet then runs `dnf check-update` because of a package has `ensure => latest` then it fails with: `Warning: Puppet::Type::Package::ProviderDnf: Could not check for updates, '/bin/dnf check-update' exited with 1`

Add assumeyes to check-update, this also makes it more consistent with the other dnf commands in yum.rb which also use "-y"