### PR TITLE
Use our branch of changelog generator

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -729,3 +729,8 @@ Style/ZeroLengthPredicate:
 # URISchemes: http, https
 Layout/LineLength:
   Max: 582
+
+Performance/DoubleStartEndWith:
+  Exclude:
+    - 'lib/puppet/ssl/certificate_request.rb'
+

--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ end
 
 group :release, optional: true do
   gem 'faraday-retry', require: false
-  gem 'github_changelog_generator', require: false
+  gem 'github_changelog_generator', require: false, git: 'https://github.com/voxpupuli/github-changelog-generator', branch: 'avoid-processing-a-single-commit-multiple-time'
 end
 
 if File.exist? "#{__FILE__}.local"


### PR DESCRIPTION
Because this repo now has many thousands more commits in it, the upstream version of the changelog generator takes a huge amount of time (6+ hours). This uses our branch which makes it far more efficient.