### PR TITLE
Update acceptance workflow for changed beaker acceptance

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -86,9 +86,15 @@ permissions:
 
 jobs:
   acceptance:
+    strategy:
+      fail-fast: false
+      matrix:
+        suite-name:
+          - openvox
+          - openvox-agent
     uses: 'OpenVoxProject/shared-actions/.github/workflows/beaker_acceptance.yml@main'
     with:
-      suite-name: openvox
+      suite-name: ${{ matrix.suite-name }}
       ref: ${{ inputs.ref }}
       fork: ${{ inputs.fork }}
       openvox-collection: ${{ inputs.collection }}

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -88,40 +88,12 @@ jobs:
   acceptance:
     uses: 'OpenVoxProject/shared-actions/.github/workflows/beaker_acceptance.yml@main'
     with:
+      suite-name: openvox
       ref: ${{ inputs.ref }}
-      project-name: openvox
       fork: ${{ inputs.fork }}
-      install-openvox: true
       openvox-collection: ${{ inputs.collection }}
       openvox-agent-version: ${{ inputs.openvox-agent-version }}
       openvox-agent-pre-release-build: ${{ inputs.pre-release-build }}
-      install-openvox-server: true
       openvox-server-version: ${{ inputs.openvox-server-version }}
       openvox-server-pre-release-build: ${{ inputs.pre-release-build }}
-      install-openvoxdb: false
-      install-openvoxdb-termini: false
       artifacts-url: ${{ inputs.artifacts-url }}
-      acceptance-working-dir: 'acceptance'
-      acceptance-pre-suite: |-
-        [
-          "pre-suite"
-        ]
-      acceptance-tests: |-
-        [
-          "tests"
-        ]
-      beaker-options: |-
-        {
-          "helper":       "lib/helper.rb",
-          "options_file": "config/aio/options.rb"
-        }
-      vms: |-
-        [
-          {
-            "role": "primary",
-            "count": 1,
-            "cpus": 4,
-            "mem_mb": 8192,
-            "cpu_mode": "host-model"
-          }
-        ]

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -32,6 +32,12 @@ on:
         required: true
         type: string
         default: main
+      fork:
+        description: |-
+          (Fork) The fork of openvox to run the Beaker test suite from.
+        required: true
+        type: string
+        default: openvoxproject
       pre-release-build:
         description: |-
           (Pre-release Build) Whether to test unreleased version
@@ -84,6 +90,7 @@ jobs:
     with:
       ref: ${{ inputs.ref }}
       project-name: openvox
+      fork: ${{ inputs.fork }}
       install-openvox: true
       openvox-collection: ${{ inputs.collection }}
       openvox-agent-version: ${{ inputs.openvox-agent-version }}


### PR DESCRIPTION
These parameters are now centralized as a set of per project defaults in
beaker_acceptance.yml and no longer need to be explicitly passed in.

Also, switches from identifying on 'project-name' to 'suite-name', since
there may be multiple test suites per repository.

---

Run both openvox and openvox-agent acceptance in a matrix
now that we have both acceptance and packaging/acceptance suites (the
later being the openvox-agent acceptance suite).

Requires openvoxproject/shared-actions#44