### PR TITLE
Correct homepage in gemspec

### DIFF
--- a/openvox.gemspec
+++ b/openvox.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables = ["puppet"]
   spec.files = Dir['[A-Z]*'] + Dir['install.rb'] + Dir['bin/*'] + Dir['lib/**/*'] + Dir['conf/*'] + Dir['man/**/*'] + Dir['tasks/*'] + Dir['locales/**/*'] + Dir['ext/**/*'] + Dir['examples/**/*']
   spec.license = "Apache-2.0"
-  spec.homepage = "https://github.com/OpenVoxProject/puppet"
+  spec.homepage = "https://github.com/OpenVoxProject/openvox"
   spec.rdoc_options = ["--title", "OpenVox - Configuration Management", "--main", "README", "--line-numbers"]
   spec.require_paths = ["lib"]
   spec.summary = "OpenVox, a community implementation of Puppet -- an automated configuration management tool"


### PR DESCRIPTION
This reflects the repository has been renamed. While there is a redirect, it's better to avoid that.