### PR TITLE
More secure default server setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -842,7 +842,7 @@ names.
 **Note:** The list of alternate names is locked in when the server's
 certificate is signed. If you need to change the list later, you can't just
 change this setting; you also need to regenerate the certificate. For more
-information on that process, see the 
+information on that process, see the
 [cert regen docs](https://puppet.com/docs/puppet/latest/ssl_regenerate_certificates.html).
 
 To see all the alternate names your servers are using, log into your CA server
@@ -1629,7 +1629,7 @@ EOT
       :desc     => "The root directory of devices' $confdir.",
     },
     :server => {
-      :default => "puppet",
+      :default => Puppet.features.root? ? 'puppet' : '', # use an empty string so dependent settings can resolve without crashing
       :desc => "The primary Puppet server to which the Puppet agent should connect. This setting is ignored when `server_list` is specified.",
     },
     :server_list => {

--- a/spec/integration/application/lookup_spec.rb
+++ b/spec/integration/application/lookup_spec.rb
@@ -56,6 +56,7 @@ describe 'lookup' do
       stub_request(:get, "https://puppet:8140/puppet-ca/v1/certificate/#{fqdn}").to_return(body: cert)
       allow(Puppet::Node::Facts.indirection).to receive(:find).and_return(facts)
 
+      Puppet[:server] = 'puppet'
       Puppet[:environment] = env_name
       Puppet[:environmentpath] = populated_env_dir
 
@@ -147,6 +148,7 @@ describe 'lookup' do
     end
 
     it 'loads trusted information from the node certificate' do
+      Puppet.settings[:server] = 'puppet'
       Puppet.settings[:node_terminus] = 'exec'
       expect_any_instance_of(Puppet::Node::Exec).to receive(:find) do |args|
         info = Puppet.lookup(:trusted_information)

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -106,6 +106,7 @@ describe Puppet::Configurer do
 
         before(:each) do
           Puppet[:resubmit_facts] = true
+          Puppet[:server] = 'puppet'
 
           allow(@configurer).to receive(:find_facts).and_return(test_facts)
         end
@@ -135,6 +136,7 @@ describe Puppet::Configurer do
         end
 
         it 'logs errors that occur during fact submission' do
+          Puppet[:server] = 'puppet'
           stub_request(:put, "https://puppet:8140/puppet/v3/facts/configurer.test?environment=production").to_return(status: 502)
           expect(Puppet).to receive(:log_exception).with(Puppet::HTTP::ResponseError,
                                                          /^Failed to submit facts/)

--- a/spec/unit/application/filebucket_spec.rb
+++ b/spec/unit/application/filebucket_spec.rb
@@ -41,6 +41,7 @@ describe Puppet::Application::Filebucket do
 
   describe "during setup" do
     before :each do
+      Puppet[:server] = 'puppet'
       allow(Puppet::Log).to receive(:newdestination)
       allow(Puppet::FileBucket::Dipper).to receive(:new)
       allow(@filebucket.options).to receive(:[])
@@ -157,6 +158,7 @@ describe Puppet::Application::Filebucket do
 
   describe "when running" do
     before :each do
+      Puppet[:server] = 'puppet'
       allow(Puppet::Log).to receive(:newdestination)
       allow(Puppet::FileBucket::Dipper).to receive(:new)
       allow(@filebucket.options).to receive(:[])
@@ -177,6 +179,7 @@ describe Puppet::Application::Filebucket do
 
     describe "the command get" do
       before :each do
+        Puppet[:server] = 'puppet'
         allow(@filebucket).to receive(:print)
         allow(@filebucket).to receive(:args).and_return([])
       end

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -23,6 +23,7 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
 
   before do
     Puppet.settings.use(:main)
+    Puppet.settings[:server] = 'puppet'
     Puppet[:certname] = name
     Puppet[:vardir] = tmpdir("ssl_testing")
 

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -8,6 +8,31 @@ describe "Defaults" do
     end
   end
 
+  describe 'server' do
+    it 'should default to `puppet` when root' do
+      allow(Puppet.features).to receive(:root?).and_return(true)
+      foo = Puppet::Settings.new
+      Puppet.initialize_default_settings!(foo)
+      expect(foo[:server]).to eq('puppet')
+    end
+
+    it 'should default to empty value when non-root' do
+      allow(Puppet.features).to receive(:root?).and_return(false)
+      foo = Puppet::Settings.new
+      Puppet.initialize_default_settings!(foo)
+      expect(foo[:server]).to eq('')
+    end
+
+    it 'should fail when trying to establish a compiler connection without setting `server`' do
+      allow(Puppet.features).to receive(:root?).and_return(false)
+      expect {
+        client = Puppet.runtime[:http]
+        session = client.create_session
+        service = session.route_to(:puppet)
+      }.to raise_exception ArgumentError, /Required setting/
+    end
+  end
+
   describe 'strict' do
     it 'should accept the valid value :off' do
       expect {Puppet.settings[:strict] = 'off'}.to_not raise_exception

--- a/spec/unit/http/resolver_spec.rb
+++ b/spec/unit/http/resolver_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 require 'puppet/http'
 
 describe Puppet::HTTP::Resolver do
+  before :each do
+    Puppet[:server] = 'puppet'
+  end
+
   let(:ssl_context) { Puppet::SSL::SSLContext.new }
   let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
   let(:session) { client.create_session }

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 require 'puppet/http'
 
 describe Puppet::HTTP::Session do
+  before :each do
+    Puppet[:server] = 'puppet'
+  end
+
   let(:ssl_context) { Puppet::SSL::SSLContext.new }
   let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
   let(:uri) { URI.parse('https://www.example.com') }

--- a/spec/unit/indirector/file_bucket_file/rest_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/rest_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 require 'puppet/indirector/file_bucket_file/rest'
 
 describe Puppet::FileBucketFile::Rest do
+  before :each do
+    Puppet[:server] = 'puppet'
+  end
+
   let(:rest_path) {"filebucket://xanadu:8141/"}
   let(:file_bucket_file) {Puppet::FileBucket::File.new('file contents', :bucket_path => '/some/random/path')}
   let(:files_original_path) {'/path/to/file'}

--- a/spec/unit/indirector/file_content/rest_spec.rb
+++ b/spec/unit/indirector/file_content/rest_spec.rb
@@ -8,6 +8,7 @@ describe Puppet::Indirector::FileContent::Rest do
   let(:key) { "puppet:///:mount/path/to/file" }
 
   before :each do
+    Puppet[:server] = 'puppet'
     described_class.indirection.terminus_class = :rest
   end
 

--- a/spec/unit/indirector/file_metadata/rest_spec.rb
+++ b/spec/unit/indirector/file_metadata/rest_spec.rb
@@ -9,6 +9,7 @@ describe Puppet::Indirector::FileMetadata::Rest do
   let(:model) { described_class.model }
 
   before :each do
+    Puppet[:server] = 'puppet'
     described_class.indirection.terminus_class = :rest
   end
 

--- a/spec/unit/indirector/report/rest_spec.rb
+++ b/spec/unit/indirector/report/rest_spec.rb
@@ -13,6 +13,7 @@ describe Puppet::Transaction::Report::Rest do
   end
 
   before(:each) do
+    Puppet[:report_server] = 'puppet'
     described_class.indirection.terminus_class = :rest
   end
 

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -28,6 +28,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
 
   before(:each) do
     Puppet[:daemonize] = false
+    Puppet[:server] = 'puppet'
     Puppet[:ssl_lockfile] = tmpfile('ssllock')
     allow(Kernel).to receive(:sleep)
     future = Time.now + (5 * 60)

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -615,6 +615,10 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
     end
 
     describe 'from remote source' do
+      before do
+        Puppet[:server] = 'puppet'
+      end
+
       let(:source_content) { "source file content\n"*10 }
       let(:source) {
         attr = resource.newattr(:source)


### PR DESCRIPTION
Under some fairly obscure conditions, defaulting the server setting to 'puppet' can be a security concern. Because the worst case scenario involves a user accidentally running `puppet agent -t` on an untrusted network, this PR removes the default completely when non-root. Otherwise, it just prints a deprecation warning.

The check and warnings are generated at the http service so that it only screams if you actually attempt to use it. This avoids, for example, the spurious deprecation message when running `puppet config set` to set this in the first place.

Fixes https://github.com/voxpupuli/security-tracking/issues/22

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
