### PR TITLE
puppet node: redeclare to identical values is a `notice` not a warning.

### DIFF
--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -155,7 +155,11 @@ class Puppet::Node
   def merge(params)
     params.each do |name, value|
       if @parameters.include?(name)
-        Puppet::Util::Warnings.warnonce(_("The node parameter '%{param_name}' for node '%{node_name}' was already set to '%{value}'. It could not be set to '%{desired_value}'") % { param_name: name, node_name: @name, value: @parameters[name], desired_value: value })
+        if @parameters[name] == value
+          Puppet::Util::Warnings.notice_once(_("The node parameter '%{param_name}' for node '%{node_name}' was already set to '%{value}'. It could not be set to '%{desired_value}'") % { param_name: name, node_name: @name, value: @parameters[name], desired_value: value })
+        else
+          Puppet::Util::Warnings.warnonce(_("The node parameter '%{param_name}' for node '%{node_name}' was already set to '%{value}'. It could not be set to '%{desired_value}'") % { param_name: name, node_name: @name, value: @parameters[name], desired_value: value })
+        end
       else
         @parameters[name] = value
       end


### PR DESCRIPTION
### Short description
On initial bootstrap my hosts have some issues getting all their classes and parameters sorted. This results in some silly looking logs.

```
puppetserver.log:2026-09-01T14:51:15.564-05:00 WARN  [qtp1853403919-973] [puppetserver] Puppet The node parameter 'slam_purpose' for node 'slam-monitoring-server' was already set to 'server'. It could not be set to 'server'
```

Since the resulting node parameter is already `server`, I'd suggest it isn't a `WARNING` so much as a `NOTICE`. Yeah, I should clean this up, but since there is no difference between what was set and what I tried to set, I'd rather log this at a lower severity.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
