### PR TITLE
Proper markdown for alias reference documentation.

### DIFF
--- a/lib/puppet/reference/metaparameter.rb
+++ b/lib/puppet/reference/metaparameter.rb
@@ -14,7 +14,7 @@ etc.), prevent OpenVox from making changes (`noop`), and change logging verbosit
 
 ## Available Metaparameters
 
-  }.dup
+  }.dup.strip + "\n"
   begin
     params = []
     Puppet::Type.eachmetaparam { |param|


### PR DESCRIPTION
### Short description

On the final web page the indentation of the alias header is wrong (2 spaces instead of no spaces).

See https://docs.openvoxproject.org/openvox/latest/metaparameter.html#available-metaparameters

This only occurs on the very first metaparameter when we append the parameter documentation to the header.
The header has 2 whitespaces on the last line.

There are two ways how to solve this:

a. fix the appending of the parameter
b. fix the header only

I decided to go for fixing the header.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
