### PR TITLE
Increase delay affordance in waitforlock test

### DIFF
--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -582,7 +582,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
     it "waits for other agent run to finish before starting" do
       server.start_server do |port|
         Puppet[:serverport] = port
-        Puppet[:waitforlock] = 1
+        Puppet[:waitforlock] = 5
 
         with_another_agent_running do
           expect {


### PR DESCRIPTION
### Short description

This increases the maximum delay in the waitforlock unit test so we avoid failing frequently on slower/busier hosts.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
