### PR TITLE
Do not swallow RunTimeoutError while collecting facts

### DIFF
--- a/lib/puppet/configurer/fact_handler.rb
+++ b/lib/puppet/configurer/fact_handler.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../../puppet/agent'
 require_relative '../../puppet/indirector/facts/facter'
 
 require_relative '../../puppet/configurer'
@@ -20,7 +21,10 @@ module Puppet::Configurer::FactHandler
       facts.name = Puppet[:node_name_value]
     end
     facts
-  rescue SystemExit, NoMemoryError
+  rescue SystemExit, NoMemoryError, Puppet::Agent::RunTimeoutError
+    # RunTimeoutError means the agent run as a whole has exceeded `runtimeout`.
+    # Let it propagate so the run is aborted instead of wrapping it in a
+    # Puppet::Error and carrying on with the rest of the run.
     raise
   rescue Exception => detail
     message = _("Could not retrieve local facts: %{detail}") % { detail: detail }

--- a/spec/unit/configurer/fact_handler_spec.rb
+++ b/spec/unit/configurer/fact_handler_spec.rb
@@ -58,6 +58,13 @@ describe Puppet::Configurer::FactHandler do
       expect { facthandler.find_facts }.to raise_error(Puppet::Error, /Could not retrieve local facts/)
     end
 
+    it "should re-raise RunTimeoutError so the agent run is aborted" do
+      expect(Puppet::Node::Facts.indirection).to receive(:find).and_raise(Puppet::Agent::RunTimeoutError, 'execution expired')
+      expect(Puppet).not_to receive(:log_exception)
+
+      expect { facthandler.find_facts }.to raise_error(Puppet::Agent::RunTimeoutError, 'execution expired')
+    end
+
     it "should only load fact plugins once" do
       expect(Puppet::Node::Facts.indirection).to receive(:find).once
       facthandler.find_facts


### PR DESCRIPTION
### Short description
`Puppet::Agent::RunTimeoutError` inherits from `Exception` so that it escapes the usual `rescue StandardError` handlers and aborts the run. The fact handler, however, rescues `Exception` and only re-raises SystemExit and NoMemoryError, so a run timeout that fires during fact collection was wrapped into a plain Puppet::Error ("Could not retrieve local facts: execution expired") and the run carried on to send a report as if nothing had happened.

Re-raise RunTimeoutError alongside SystemExit and NoMemoryError so the agent aborts the run as intended.

Fixes part of #485

_Generated by Claude Code_

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
