### PR TITLE
Fix systemd unreferenced variable warning on Debian

### DIFF
--- a/ext/debian/puppet.default
+++ b/ext/debian/puppet.default
@@ -1,4 +1,4 @@
-# Defaults for puppet - sourced by /etc/init.d/puppet
+# Defaults for puppet - sourced by /etc/init.d/puppet and puppet.service
 
 # Startup options
-DAEMON_OPTS=""
+PUPPET_EXTRA_OPTS=""

--- a/ext/debian/puppet.init
+++ b/ext/debian/puppet.init
@@ -9,7 +9,7 @@
 ### END INIT INFO
 
 DAEMON=/opt/puppetlabs/puppet/bin/puppet
-DAEMON_OPTS=""
+PUPPET_EXTRA_OPTS=""
 NAME="agent"
 PROCNAME="puppet"
 DESC="puppet agent"
@@ -26,7 +26,7 @@ reload_puppet_agent() {
 }
 
 start_puppet_agent() {
-    start-stop-daemon --start --quiet --pidfile $PIDFILE --startas $DAEMON -- $NAME $DAEMON_OPTS
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --startas $DAEMON -- $NAME $PUPPET_EXTRA_OPTS
 }
 
 stop_puppet_agent() {


### PR DESCRIPTION
### Short description

Currently when starting puppet.service on Debian the following message is emitted:

    puppet.service: Referenced but unset environment variable evaluates
    to an empty string: PUPPET_EXTRA_OPTS

This is because puppet.default is used both by the systemd and sysvinit scripts.

Ths fix is to replace $DAEMON_OPTS with $PUPPET_EXTRA_OPTS.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
