### PR TITLE
Install the service defaults file on Debian

### DIFF
--- a/packaging/configs/components/puppet.rb
+++ b/packaging/configs/components/puppet.rb
@@ -12,7 +12,11 @@ component "puppet" do |pkg, settings, platform|
   platform.get_service_types.each do |servicetype|
     case servicetype
     when "systemd"
-      pkg.install_service "ext/systemd/puppet.service", "ext/redhat/client.sysconfig", init_system: servicetype
+      if platform.is_deb?
+        pkg.install_service "ext/debian/puppet.service", "ext/debian/puppet.default", init_system: servicetype
+      elsif platform.is_rpm?
+        pkg.install_service "ext/systemd/puppet.service", "ext/redhat/client.sysconfig", init_system: servicetype
+      end
     when "sysv"
       if platform.is_deb?
         pkg.install_service "ext/debian/puppet.init", "ext/debian/puppet.default", init_system: servicetype


### PR DESCRIPTION
### Short description

Tweak the packaging so that the defaults file is actually installed on Debian.

The systemd unit file definition already refers to `/etc/default/puppet`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
