### PR TITLE
Fix failing specs when test host uses base service provider

### DIFF
--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -335,7 +335,7 @@ describe test_title, "when retrieving the host's current state" do
   end
 
   it "should ask the provider whether it is enabled" do
-    allow(@service.provider.class).to receive(:supports_parameter?).and_return(true)
+    skip "unsupported by host environment" unless @service.provider.class.supports_parameter?(:enable)
     expect(@service.provider).to receive(:enabled?).and_return(:yepper)
     @service[:enable] = true
     expect(@service.property(:enable).retrieve).to eq(:yepper)
@@ -362,14 +362,14 @@ describe test_title, "when changing the host" do
   end
 
   it "should enable the service if it is supposed to be enabled" do
-    allow(@service.provider.class).to receive(:supports_parameter?).and_return(true)
+    skip "unsupported by host environment" unless @service.provider.class.supports_parameter?(:enable)
     @service[:enable] = true
     expect(@service.provider).to receive(:enable)
     @service.property(:enable).sync
   end
 
   it "should disable the service if it is supposed to be disabled" do
-    allow(@service.provider.class).to receive(:supports_parameter?).and_return(true)
+    skip "unsupported by host environment" unless @service.provider.class.supports_parameter?(:enable)
     @service[:enable] = false
     expect(@service.provider).to receive(:disable)
     @service.property(:enable).sync


### PR DESCRIPTION
### Short description

In some build environments such as Debian's pbuilder, the host's /proc might be mounted in the build environment, but the systemctl executable is missing from the chroot, since it's not a strict build dependency.

In such environments, the base service provider will be selected, which doesn't support the :enable parameter, leading to such failures:

    Service[yay](provider=base) does not implement: enable

Instead of forcing the host's service provider to report support for the enable parameter, simply skip the test when it isn't available.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x]  added or modified unit test(s)
