### PR TITLE
Document --environment in puppet agent help

### DIFF
--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -258,8 +258,10 @@ class Puppet::Application::Agent < Puppet::Application
         recorded by the previous run and the node request to the server, which is
         how it picks an environment otherwise. This is the usual way to move an
         agent out of an environment it switched to on an earlier run. The server
-        can still return a catalog for a different environment, for example when
-        an ENC assigns one, unless 'strict_environment_mode' is set.
+        can still assign a different environment, for example through an ENC. In
+        that case the agent switches to the server's environment and requests
+        the catalog again. If 'strict_environment_mode' is set, the agent refuses
+        the mismatched catalog and fails the run instead of switching.
         (This is an OpenVox setting, and can go in puppet.conf.)
 
       *  --evaltrace:

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -103,9 +103,13 @@ class Puppet::Application::Agent < Puppet::Application
       -----
       puppet agent [--certname <NAME>] [-D|--daemonize|--no-daemonize]
         [-d|--debug] [--detailed-exitcodes] [--digest <DIGEST>] [--disable [MESSAGE]] [--enable]
-        [--fingerprint] [-h|--help] [-l|--logdest syslog|eventlog|<ABS FILEPATH>|console]
+        [--environment <NAME>] [--fingerprint] [-h|--help]
+        [-l|--logdest syslog|eventlog|<ABS FILEPATH>|console]
         [--serverport <PORT>] [--noop] [-o|--onetime] [--sourceaddress <IP_ADDRESS>] [-t|--test]
-        [-v|--verbose] [-V|--version] [-w|--waitforcert <SECONDS>]
+        [-v|--verbose] [-V|--version] [-w|--waitforcert <SECONDS>] [--<setting> <VALUE>]
+
+      Any setting that is valid in puppet.conf is also accepted as a long argument,
+      not only the ones listed above. See OPTIONS below.
 
 
       DESCRIPTION
@@ -199,8 +203,7 @@ class Puppet::Application::Agent < Puppet::Application
 
       * --no-daemonize:
         Do not send the process into the background.
-        (This is an OpenVox setting, and can go in puppet.conf. Note the special 'no-'
-        prefix for boolean settings on the command line.)
+        (This is an OpenVox setting, and can go in puppet.conf.)
 
       * --debug:
         Enable full debugging.
@@ -248,6 +251,16 @@ class Puppet::Application::Agent < Puppet::Application
         not start for another half hour.
 
         'puppet agent' exits after executing this.
+
+      * --environment:
+        Request a catalog for the given environment. When set on the command line,
+        the agent uses this environment directly and skips both the environment
+        recorded by the previous run and the node request to the server, which is
+        how it picks an environment otherwise. This is the usual way to move an
+        agent out of an environment it switched to on an earlier run. The server
+        can still return a catalog for a different environment, for example when
+        an ENC assigns one, unless 'strict_environment_mode' is set.
+        (This is an OpenVox setting, and can go in puppet.conf.)
 
       *  --evaltrace:
         Logs each resource as it is being evaluated. This allows you to interactively

--- a/man/man8/puppet-agent.8
+++ b/man/man8/puppet-agent.8
@@ -77,7 +77,7 @@ Disable can also take an optional message that will be reported by the 'puppet a
 .IP
 \&'puppet agent' exits after executing this\.
 .IP "\(bu" 4
-\-\-environment: Request a catalog for the given environment\. When set on the command line, the agent uses this environment directly and skips both the environment recorded by the previous run and the node request to the server, which is how it picks an environment otherwise\. This is the usual way to move an agent out of an environment it switched to on an earlier run\. The server can still return a catalog for a different environment, for example when an ENC assigns one, unless 'strict_environment_mode' is set\. (This is an OpenVox setting, and can go in puppet\.conf\.)
+\-\-environment: Request a catalog for the given environment\. When set on the command line, the agent uses this environment directly and skips both the environment recorded by the previous run and the node request to the server, which is how it picks an environment otherwise\. This is the usual way to move an agent out of an environment it switched to on an earlier run\. The server can still assign a different environment, for example through an ENC\. In that case the agent switches to the server's environment and requests the catalog again\. If 'strict_environment_mode' is set, the agent refuses the mismatched catalog and fails the run instead of switching\. (This is an OpenVox setting, and can go in puppet\.conf\.)
 .IP "\(bu" 4
 \-\-evaltrace: Logs each resource as it is being evaluated\. This allows you to interactively see exactly what is being done\. (This is an OpenVox setting, and can go in puppet\.conf\. Note the special 'no\-' prefix for boolean settings on the command line\.)
 .IP "\(bu" 4

--- a/man/man8/puppet-agent.8
+++ b/man/man8/puppet-agent.8
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "PUPPET\-AGENT" "8" "August 2026" "Vox Pupuli" "OpenVox manual"
+.TH "PUPPET\-AGENT" "8" "September 2026" "Vox Pupuli" "OpenVox manual"
 .SH "NAME"
 \fBpuppet\-agent\fR \- The puppet agent daemon provided by OpenVox
 .SH "SYNOPSIS"
@@ -8,7 +8,9 @@ Retrieves the client configuration from the OpenVox server and applies it to the
 .P
 This service may be run as a daemon, run periodically using cron (or something similar), or run interactively for testing purposes\.
 .SH "USAGE"
-puppet agent [\-\-certname \fINAME\fR] [\-D|\-\-daemonize|\-\-no\-daemonize] [\-d|\-\-debug] [\-\-detailed\-exitcodes] [\-\-digest \fIDIGEST\fR] [\-\-disable [MESSAGE]] [\-\-enable] [\-\-fingerprint] [\-h|\-\-help] [\-l|\-\-logdest syslog|eventlog|\fIABS FILEPATH\fR|console] [\-\-serverport \fIPORT\fR] [\-\-noop] [\-o|\-\-onetime] [\-\-sourceaddress \fIIP_ADDRESS\fR] [\-t|\-\-test] [\-v|\-\-verbose] [\-V|\-\-version] [\-w|\-\-waitforcert \fISECONDS\fR]
+puppet agent [\-\-certname \fINAME\fR] [\-D|\-\-daemonize|\-\-no\-daemonize] [\-d|\-\-debug] [\-\-detailed\-exitcodes] [\-\-digest \fIDIGEST\fR] [\-\-disable [MESSAGE]] [\-\-enable] [\-\-environment \fINAME\fR] [\-\-fingerprint] [\-h|\-\-help] [\-l|\-\-logdest syslog|eventlog|\fIABS FILEPATH\fR|console] [\-\-serverport \fIPORT\fR] [\-\-noop] [\-o|\-\-onetime] [\-\-sourceaddress \fIIP_ADDRESS\fR] [\-t|\-\-test] [\-v|\-\-verbose] [\-V|\-\-version] [\-w|\-\-waitforcert \fISECONDS\fR] [\-\-\fIsetting\fR \fIVALUE\fR]
+.P
+Any setting that is valid in puppet\.conf is also accepted as a long argument, not only the ones listed above\. See OPTIONS below\.
 .SH "DESCRIPTION"
 This is the main OpenVox client\. Its job is to retrieve the local machine's configuration from a remote server and apply it\. In order to successfully communicate with the remote server, the client must have a certificate signed by a certificate authority that the server trusts; the recommended method for this, at the moment, is to run a certificate authority as part of the OpenVox server (which is the default)\. The client will connect and request a signed certificate, and will continue connecting until it receives one\.
 .P
@@ -45,7 +47,7 @@ See the configuration file documentation at https://docs\.openvoxproject\.org/op
 .IP "\(bu" 4
 \-\-daemonize: Send the process into the background\. This is the default\. (This is an OpenVox setting, and can go in puppet\.conf\. Note the special 'no\-' prefix for boolean settings on the command line\.)
 .IP "\(bu" 4
-\-\-no\-daemonize: Do not send the process into the background\. (This is an OpenVox setting, and can go in puppet\.conf\. Note the special 'no\-' prefix for boolean settings on the command line\.)
+\-\-no\-daemonize: Do not send the process into the background\. (This is an OpenVox setting, and can go in puppet\.conf\.)
 .IP "\(bu" 4
 \-\-debug: Enable full debugging\.
 .IP "\(bu" 4
@@ -74,6 +76,8 @@ Disable can also take an optional message that will be reported by the 'puppet a
 \-\-enable: Enable working on the local system\. This removes any lock file, causing 'puppet agent' to start managing the local system again However, it continues to use its normal scheduling, so it might not start for another half hour\.
 .IP
 \&'puppet agent' exits after executing this\.
+.IP "\(bu" 4
+\-\-environment: Request a catalog for the given environment\. When set on the command line, the agent uses this environment directly and skips both the environment recorded by the previous run and the node request to the server, which is how it picks an environment otherwise\. This is the usual way to move an agent out of an environment it switched to on an earlier run\. The server can still return a catalog for a different environment, for example when an ENC assigns one, unless 'strict_environment_mode' is set\. (This is an OpenVox setting, and can go in puppet\.conf\.)
 .IP "\(bu" 4
 \-\-evaltrace: Logs each resource as it is being evaluated\. This allows you to interactively see exactly what is being done\. (This is an OpenVox setting, and can go in puppet\.conf\. Note the special 'no\-' prefix for boolean settings on the command line\.)
 .IP "\(bu" 4


### PR DESCRIPTION
## Summary

Fixes #652, raised by @defnull while reviewing OpenVoxProject/openvox-docs#477.

`puppet agent --help` listed about twenty options in USAGE and nothing else, so it read as an exhaustive list. The only hint that any `puppet.conf` setting is accepted as a long argument was a prose note fifty lines further down at the top of OPTIONS, which is easy to miss when scanning for a specific flag.

Changes to the help text in `lib/puppet/application/agent.rb`:

- **Add `--environment` to USAGE and OPTIONS.** It is the one setting whose command-line form changes agent behaviour beyond overriding the config value: `lib/puppet/configurer.rb` checks `set_by_cli?(:environment)` and, when true, skips both the last-run environment and the node request. That is the documented way to move an agent out of an environment it switched to on an earlier run. The entry also notes that an ENC can still redirect the run unless `strict_environment_mode` is set.
- **Add a generic `[--<setting> <VALUE>]` to USAGE** with a sentence pointing at the OPTIONS note.
- **Drop the "Note the special 'no-' prefix" sentence from the `--no-daemonize` entry.** That entry is itself the `no-` form, and the OPTIONS intro already uses `--daemonize` / `--no-daemonize` as its worked example.
- **Regenerate `man/man8/puppet-agent.8`.** Only the agent page is included; the other pages changed by `rake gen_manpages` differed only in the date header.

## Verification

- `bundle exec rubocop lib/puppet/application/agent.rb`: no offenses
- `bundle exec rspec spec/unit/application/agent_spec.rb`: 87 examples, 0 failures
- `bundle exec puppet agent --help`: USAGE and the new `--environment` entry render as intended
- `mandoc -Tlint` on the regenerated page: only the pre-existing date-format warning

Assisted by Claude.
