### PR TITLE
Pin json below 3 to unblock CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ group(:packaging) do
     gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || 'https://github.com/openvoxproject/vanagon#main')
   end
   gem 'artifactory'
-  gem 'json'
+  gem 'json', '< 3'
   gem 'octokit'
 end
 


### PR DESCRIPTION
## Summary

Part of #654.

json 3.0.0, released 2026-09-07, makes every option a keyword argument and removes `JSON::PRETTY_STATE_PROTOTYPE` and `JSON.pretty_unparse`. The `Gemfile` declares `json` without a constraint and `Gemfile.lock` is not tracked, so every CI run since then resolves 3.0.0 and `Puppet::Util::Json` raises on every `JSON.parse` call. The ruby 3.4 job on #653 had 1590 spec failures from this.

This pins `json` below 3 in the `:packaging` group, which is the only place it is declared. It is not a gemspec runtime dependency, so this changes nothing for installed agents; they keep using the json bundled with their Ruby.

The constraint also gives Dependabot something to propose bumping. It couldn't open a PR for an unconstrained gem with no lockfile, which is why this wasn't caught.

Porting `Puppet::Util::Json` to the json 3 API is tracked in #654 and should follow, since a future Ruby release will ship json 3 as its default gem.

## Verification

- `bundle check` resolves with the pin. The local lockfile already had json 2.20.0, so nothing else moves.
- CI on this PR is the real test.

Assisted by Claude.
