### PR TITLE
print "Loading facts" just once

### DIFF
--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -64,7 +64,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
 
     dirs.select! { |dir| FileTest.directory?(dir) }
 
-    # Even through we no longer directly load facts in the terminus,
+    # Even though we no longer directly load facts in the terminus,
     # print out each .rb in the facts directory as module
     # developers may find that information useful for debugging purposes
     if Puppet::Util::Log.sendlevel?(:info) && !dirs.empty?

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -62,21 +62,20 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
       end
     end.flatten + Puppet[:factpath].split(File::PATH_SEPARATOR)
 
-    dirs = dirs.select do |dir|
-      next false unless FileTest.directory?(dir)
+    dirs.select! { |dir| FileTest.directory?(dir) }
 
-      # Even through we no longer directly load facts in the terminus,
-      # print out each .rb in the facts directory as module
-      # developers may find that information useful for debugging purposes
-      if Puppet::Util::Log.sendlevel?(:info)
-        Puppet.info _("Loading facts")
+    # Even through we no longer directly load facts in the terminus,
+    # print out each .rb in the facts directory as module
+    # developers may find that information useful for debugging purposes
+    if Puppet::Util::Log.sendlevel?(:info) && !dirs.empty?
+      Puppet.info _("Loading facts")
+      dirs.each do |dir|
         Dir.glob("#{dir}/*.rb").each do |file|
           Puppet.debug { "Loading facts from #{file}" }
         end
       end
-
-      true
     end
+
     dirs << request.options[:custom_dir] if request.options[:custom_dir]
     Puppet.runtime[:facter].search(*dirs)
   end

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -67,11 +67,13 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     # Even though we no longer directly load facts in the terminus,
     # print out each .rb in the facts directory as module
     # developers may find that information useful for debugging purposes
-    if Puppet::Util::Log.sendlevel?(:info) && !dirs.empty?
+    unless dirs.empty?
       Puppet.info _("Loading facts")
-      dirs.each do |dir|
-        Dir.glob("#{dir}/*.rb").each do |file|
-          Puppet.debug { "Loading facts from #{file}" }
+      if Puppet::Util::Log.sendlevel?(:debug)
+        dirs.each do |dir|
+          Dir.glob("#{dir}/*.rb").each do |file|
+            Puppet.debug { "Loading facts from #{file}" }
+          end
         end
       end
     end


### PR DESCRIPTION
in the past, we printed "Loading facts" for every directory where we search for facts. This just created a bunch of noise.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
