### PR TITLE
fix(http): allow server_list to satisfy missing server validation

### DIFF
--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -14,6 +14,13 @@ class Puppet::HTTP::Service
   # @return [Array<Symbol>] format types that are unsupported
   EXCLUDED_FORMATS = [:yaml, :b64_zlib_yaml, :dot].freeze
 
+  def self.server_list_configured?
+    server_list = Puppet.settings.setting(:server_list).value
+    server_list && !server_list.empty?
+  end
+
+  private_class_method :server_list_configured?
+
   # Create a new web service, which contains the URL used to connect to the
   # service. The four services implemented are `:ca`, `:fileserver`, `:puppet`,
   # and `:report`.
@@ -33,12 +40,12 @@ class Puppet::HTTP::Service
   # @api private
   def self.create_service(client, session, name, server = nil, port = nil)
     # this is the entry point for creating all services, check and issue error(s)/warning(s) here.
-    unless Puppet.settings.set_by_config? :server
+    unless server || Puppet.settings.set_by_config?(:server) || server_list_configured?
       if Puppet.features.root?
         error_message = <<~MSG
-          OpenVox does not default to `server=puppet` as of version 9.0. Please update your configuration appropriately by providing a specific server of your choice.
+          OpenVox does not default to `server=puppet` as of version 9.0. Please update your configuration appropriately by providing a specific server or `server_list` of your choice.
 
-          You can update the server setting in puppet.conf by running a command similar to:
+          E.g., you can update the `server` setting in puppet.conf by running a command similar to:
             puppet config --section main set server YOUR_SERVER_NAME
         MSG
         raise ArgumentError, error_message
@@ -47,11 +54,11 @@ class Puppet::HTTP::Service
 
         case name
         when :ca
-          raise ArgumentError, 'Neither `server` nor `ca_server` is specified.' unless Puppet.settings.set_by_config? :ca_server
+          raise ArgumentError, 'Neither `server`, `server_list`, nor `ca_server` is specified.' unless Puppet.settings.set_by_config? :ca_server
         when :report
-          raise ArgumentError, 'Neither `server` nor `report_server` is specified.' unless Puppet.settings.set_by_config? :report_server
+          raise ArgumentError, 'Neither `server`, `server_list`, nor `report_server` is specified.' unless Puppet.settings.set_by_config? :report_server
         when :fileserver, :puppet, :puppetserver
-          raise ArgumentError, 'Required setting `server` is not specified.'
+          raise ArgumentError, 'Required setting `server` or `server_list` is not specified.'
         end
       end
     end

--- a/spec/unit/http/service_spec.rb
+++ b/spec/unit/http/service_spec.rb
@@ -125,7 +125,21 @@ describe Puppet::HTTP::Service do
     expect {
       # following call is needed to trigger above warning
       described_class.create_service(client, session, :puppet)
-    }.to raise_error(ArgumentError, 'Required setting `server` is not specified.')
+    }.to raise_error(ArgumentError, 'Required setting `server` or `server_list` is not specified.')
+  end
+
+  it 'allows server_list to satisfy the guard when an explicit server is provided' do
+    allow(Puppet.settings).to receive(:set_by_config?).and_call_original
+    allow(Puppet.settings).to receive(:set_by_config?).with(:server).and_return(false)
+    allow(Puppet.settings).to receive(:setting).with(:server_list).and_return(double(value: [%w[puppet.example.com 8140]]))
+    allow(Puppet.features).to receive(:root?).and_return(false)
+
+    expect(Puppet).not_to receive(:deprecation_warning)
+
+    service = described_class.create_service(client, session, :puppet, 'puppet.example.com', 8140)
+
+    expect(service).to be_an_instance_of(Puppet::HTTP::Service::Compiler)
+    expect(service.url.to_s).to eq('https://puppet.example.com:8140/puppet/v3')
   end
 
   [:ca].each do |name|


### PR DESCRIPTION
OpenVox recently tightened HTTP service creation checks so that a missing `server` setting now raises an error. That unintentionally broke valid configurations that rely on `server_list` instead of a single `server`.

Update `Puppet::HTTP::Service.create_service` to treat `server_list` as a valid source of server configuration when no explicit server argument is provided. This keeps the security-related no-default-server behavior intact while restoring compatibility for agents configured via `server_list`.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
