### PR TITLE
Accept ca_server and report_server without server when running as root

### DIFF
--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -32,29 +32,10 @@ class Puppet::HTTP::Service
   #
   # @api private
   def self.create_service(client, session, name, server = nil, port = nil)
-    # this is the entry point for creating all services, check and issue error(s)/warning(s) here.
-    unless Puppet.settings.set_by_config? :server
-      if Puppet.features.root?
-        error_message = <<~MSG
-          OpenVox does not default to `server=puppet` as of version 9.0. Please update your configuration appropriately by providing a specific server of your choice.
-
-          You can update the server setting in puppet.conf by running a command similar to:
-            puppet config --section main set server YOUR_SERVER_NAME
-        MSG
-        raise ArgumentError, error_message
-      else
-        Puppet.deprecation_warning('OpenVox no longer defaults to `server=puppet` when running as a non-privileged user. (Did you mean to run as root?)')
-
-        case name
-        when :ca
-          raise ArgumentError, 'Neither `server` nor `ca_server` is specified.' unless Puppet.settings.set_by_config? :ca_server
-        when :report
-          raise ArgumentError, 'Neither `server` nor `report_server` is specified.' unless Puppet.settings.set_by_config? :report_server
-        when :fileserver, :puppet, :puppetserver
-          raise ArgumentError, 'Required setting `server` is not specified.'
-        end
-      end
-    end
+    # Resolvers that already know which server to use (SRV records,
+    # server_list, or an explicit URL) pass it in. Only fall back on the
+    # `server` setting, and complain if it is missing, when they don't.
+    check_server_setting(name) if server.nil?
 
     case name
     when :ca
@@ -69,6 +50,39 @@ class Puppet::HTTP::Service
       Puppet::HTTP::Service::Report.new(client, session, server, port)
     else
       raise ArgumentError, "Unknown service #{name}"
+    end
+  end
+
+  # Verify that the setting a service falls back on when no explicit server is
+  # given has been configured. OpenVox no longer defaults `server` to `puppet`.
+  #
+  # @param [Symbol] name the type of service being created
+  #
+  # @raise [ArgumentError] if the service cannot determine which server to use
+  #
+  # @api private
+  def self.check_server_setting(name)
+    return if Puppet.settings.set_by_config? :server
+
+    if Puppet.features.root?
+      error_message = <<~MSG
+        OpenVox does not default to `server=puppet` as of version 9.0. Please update your configuration appropriately by providing a specific server of your choice.
+
+        You can update the server setting in puppet.conf by running a command similar to:
+          puppet config --section main set server YOUR_SERVER_NAME
+      MSG
+      raise ArgumentError, error_message
+    end
+
+    Puppet.deprecation_warning('OpenVox no longer defaults to `server=puppet` when running as a non-privileged user. (Did you mean to run as root?)')
+
+    case name
+    when :ca
+      raise ArgumentError, 'Neither `server` nor `ca_server` is specified.' unless Puppet.settings.set_by_config? :ca_server
+    when :report
+      raise ArgumentError, 'Neither `server` nor `report_server` is specified.' unless Puppet.settings.set_by_config? :report_server
+    when :fileserver, :puppet, :puppetserver
+      raise ArgumentError, 'Required setting `server` is not specified.'
     end
   end
 

--- a/lib/puppet/http/service.rb
+++ b/lib/puppet/http/service.rb
@@ -64,6 +64,14 @@ class Puppet::HTTP::Service
   def self.check_server_setting(name)
     return if Puppet.settings.set_by_config? :server
 
+    # These services fall back on their own setting before `server`
+    case name
+    when :ca
+      return if Puppet.settings.set_by_config? :ca_server
+    when :report
+      return if Puppet.settings.set_by_config? :report_server
+    end
+
     if Puppet.features.root?
       error_message = <<~MSG
         OpenVox does not default to `server=puppet` as of version 9.0. Please update your configuration appropriately by providing a specific server of your choice.
@@ -78,9 +86,9 @@ class Puppet::HTTP::Service
 
     case name
     when :ca
-      raise ArgumentError, 'Neither `server` nor `ca_server` is specified.' unless Puppet.settings.set_by_config? :ca_server
+      raise ArgumentError, 'Neither `server` nor `ca_server` is specified.'
     when :report
-      raise ArgumentError, 'Neither `server` nor `report_server` is specified.' unless Puppet.settings.set_by_config? :report_server
+      raise ArgumentError, 'Neither `server` nor `report_server` is specified.'
     when :fileserver, :puppet, :puppetserver
       raise ArgumentError, 'Required setting `server` is not specified.'
     end

--- a/spec/unit/http/resolver_spec.rb
+++ b/spec/unit/http/resolver_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 require 'puppet/http'
 
 describe Puppet::HTTP::Resolver do
-  before :each do
-    Puppet[:server] = 'puppet'
-  end
-
   let(:ssl_context) { Puppet::SSL::SSLContext.new }
   let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
   let(:session) { client.create_session }
@@ -13,6 +9,10 @@ describe Puppet::HTTP::Resolver do
 
   context 'when resolving using settings' do
     let(:subject) { Puppet::HTTP::Resolver::Settings.new(client) }
+
+    before :each do
+      Puppet[:server] = 'puppet'
+    end
 
     it 'returns a service based on the current ca_server and ca_port settings' do
       Puppet[:ca_server] = 'ca.example.com'
@@ -37,6 +37,15 @@ describe Puppet::HTTP::Resolver do
       service = subject.resolve(session, :ca)
       expect(service).to be_an_instance_of(Puppet::HTTP::Service::Ca)
       expect(service.url.to_s).to eq("https://ca.example.com:8141/puppet-ca/v1")
+    end
+
+    it 'does not require the server setting' do
+      allow(Puppet.features).to receive(:root?).and_return(true)
+      stub_request(:get, "https://ca.example.com:8141/status/v1/simple/server").to_return(status: 200)
+
+      service = subject.resolve(session, :puppet)
+      expect(service).to be_an_instance_of(Puppet::HTTP::Service::Compiler)
+      expect(service.url.to_s).to eq("https://ca.example.com:8141/puppet/v3")
     end
 
     it 'returns a service based on the current server_list setting if the server returns any success codes' do
@@ -127,6 +136,15 @@ describe Puppet::HTTP::Resolver do
     end
 
     it 'returns a service based on an SRV record' do
+      stub_srv('ca1.example.com', 8142)
+
+      service = subject.resolve(session, :ca)
+      expect(service).to be_an_instance_of(Puppet::HTTP::Service::Ca)
+      expect(service.url.to_s).to eq("https://ca1.example.com:8142/puppet-ca/v1")
+    end
+
+    it 'does not require the server setting' do
+      allow(Puppet.features).to receive(:root?).and_return(true)
       stub_srv('ca1.example.com', 8142)
 
       service = subject.resolve(session, :ca)

--- a/spec/unit/http/service_spec.rb
+++ b/spec/unit/http/service_spec.rb
@@ -128,6 +128,51 @@ describe Puppet::HTTP::Service do
     }.to raise_error(ArgumentError, 'Required setting `server` is not specified.')
   end
 
+  context 'when server is unconfigured' do
+    before :each do
+      allow(Puppet.settings).to receive(:set_by_config?).and_call_original
+      allow(Puppet.settings).to receive(:set_by_config?).with(:server).and_return(false)
+    end
+
+    [true, false].each do |root|
+      context "while running as #{root ? 'root' : 'non-root'}" do
+        before :each do
+          allow(Puppet.features).to receive(:root?).and_return(root)
+        end
+
+        it 'creates the ca service when ca_server is configured' do
+          Puppet[:ca_server] = 'ca.example.com'
+          expect(Puppet).not_to receive(:deprecation_warning)
+
+          service = described_class.create_service(client, session, :ca)
+          expect(service).to be_an_instance_of(Puppet::HTTP::Service::Ca)
+          expect(service.url.to_s).to eq('https://ca.example.com:8140/puppet-ca/v1')
+        end
+
+        it 'creates the report service when report_server is configured' do
+          Puppet[:report_server] = 'report.example.com'
+          expect(Puppet).not_to receive(:deprecation_warning)
+
+          service = described_class.create_service(client, session, :report)
+          expect(service).to be_an_instance_of(Puppet::HTTP::Service::Report)
+          expect(service.url.to_s).to eq('https://report.example.com:8140/puppet/v3')
+        end
+
+        it 'raises for the ca service when ca_server is not configured' do
+          expect {
+            described_class.create_service(client, session, :ca)
+          }.to raise_error(ArgumentError, root ? /OpenVox does not default to `server=puppet`/ : 'Neither `server` nor `ca_server` is specified.')
+        end
+
+        it 'raises for the report service when report_server is not configured' do
+          expect {
+            described_class.create_service(client, session, :report)
+          }.to raise_error(ArgumentError, root ? /OpenVox does not default to `server=puppet`/ : 'Neither `server` nor `report_server` is specified.')
+        end
+      end
+    end
+  end
+
   context 'when an explicit server is given' do
     before :each do
       allow(Puppet.settings).to receive(:set_by_config?).and_call_original

--- a/spec/unit/http/service_spec.rb
+++ b/spec/unit/http/service_spec.rb
@@ -128,6 +128,30 @@ describe Puppet::HTTP::Service do
     }.to raise_error(ArgumentError, 'Required setting `server` is not specified.')
   end
 
+  context 'when an explicit server is given' do
+    before :each do
+      allow(Puppet.settings).to receive(:set_by_config?).and_call_original
+      allow(Puppet.settings).to receive(:set_by_config?).with(:server).and_return(false)
+    end
+
+    it 'does not require the server setting while running as root' do
+      allow(Puppet.features).to receive(:root?).and_return(true)
+
+      service = described_class.create_service(client, session, :puppet, 'compiler.example.com', 8140)
+      expect(service).to be_an_instance_of(Puppet::HTTP::Service::Compiler)
+      expect(service.url.to_s).to eq('https://compiler.example.com:8140/puppet/v3')
+    end
+
+    it 'does not warn about the server setting while running as non-root' do
+      allow(Puppet.features).to receive(:root?).and_return(false)
+      expect(Puppet).not_to receive(:deprecation_warning)
+
+      service = described_class.create_service(client, session, :ca, 'ca.example.com', 8141)
+      expect(service).to be_an_instance_of(Puppet::HTTP::Service::Ca)
+      expect(service.url.to_s).to eq('https://ca.example.com:8141/puppet-ca/v1')
+    end
+  end
+
   [:ca].each do |name|
     it "returns true for #{name}" do
       expect(described_class.valid_name?(name)).to eq(true)

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 require 'puppet/http'
 
 describe Puppet::HTTP::Session do
-  before :each do
-    Puppet[:server] = 'puppet'
-  end
-
   let(:ssl_context) { Puppet::SSL::SSLContext.new }
   let(:client) { Puppet::HTTP::Client.new(ssl_context: ssl_context) }
   let(:uri) { URI.parse('https://www.example.com') }
@@ -126,6 +122,10 @@ describe Puppet::HTTP::Session do
   context 'when resolving using multiple resolvers' do
     let(:session) { client.create_session }
 
+    before :each do
+      Puppet[:server] = 'puppet'
+    end
+
     it "prefers SRV records" do
       Puppet[:use_srv_records] = true
       Puppet[:server_list] = 'foo.example.com,bar.example.com,baz.example.com'
@@ -223,6 +223,51 @@ describe Puppet::HTTP::Session do
       client.create_session.route_to(:puppet)
 
       expect(req).to have_been_requested.twice
+    end
+  end
+
+  context 'when the server setting is not configured' do
+    let(:session) { client.create_session }
+
+    before :each do
+      allow(Puppet.features).to receive(:root?).and_return(true)
+    end
+
+    it 'resolves using server_list' do
+      Puppet[:server_list] = 'apple.example.com'
+      stub_request(:get, "https://apple.example.com:8140/status/v1/simple/server").to_return(status: 200)
+
+      expect(session.route_to(:puppet).url.to_s).to eq("https://apple.example.com:8140/puppet/v3")
+    end
+
+    it 'resolves using SRV records' do
+      Puppet[:use_srv_records] = true
+      Puppet[:srv_domain] = 'example.com'
+      allow_any_instance_of(Puppet::HTTP::DNS).to receive(:each_srv_record).and_yield('mars.example.srv', 8140)
+
+      expect(session.route_to(:puppet).url.to_s).to eq("https://mars.example.srv:8140/puppet/v3")
+    end
+
+    it 'routes to a puppet URL with an explicit host' do
+      url = URI("puppet://example.com:8140/:modules/:module/path/to/file")
+
+      expect(session.route_to(:fileserver, url: url).url.to_s).to eq("https://example.com:8140/puppet/v3")
+    end
+
+    it 'does not warn while running as non-root when server_list is used' do
+      allow(Puppet.features).to receive(:root?).and_return(false)
+      expect(Puppet).not_to receive(:deprecation_warning)
+
+      Puppet[:server_list] = 'apple.example.com'
+      stub_request(:get, "https://apple.example.com:8140/status/v1/simple/server").to_return(status: 200)
+
+      expect(session.route_to(:puppet).url.to_s).to eq("https://apple.example.com:8140/puppet/v3")
+    end
+
+    it 'raises when falling back on the server setting' do
+      expect {
+        session.route_to(:puppet)
+      }.to raise_error(ArgumentError, /OpenVox does not default to `server=puppet` as of version 9\.0/)
     end
   end
 


### PR DESCRIPTION
### Short description
The `:ca` and `:report` services fall back on `ca_server` and `report_server` before `server`. When running as a non-privileged user those settings were already enough, but as root any missing `server` setting raised, and the deprecation warning fired even when the service-specific setting was configured.

Check the service-specific settings first, for both root and non-root, so the two code paths agree on which setting is required.

_Generated by Claude Code_

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
